### PR TITLE
Using "--exit-zero" instead of "ignore_errors" to propagate flake8 internal errors

### DIFF
--- a/bot/reviewbot/tools/flake8.py
+++ b/bot/reviewbot/tools/flake8.py
@@ -76,8 +76,7 @@ class Flake8Tool(Tool):
                 '--ignore=%s' % settings['ignore'],
                 path,
             ],
-            split_lines=True,
-            ignore_errors=True)
+            split_lines=True)
 
         for line in output:
             try:

--- a/bot/reviewbot/tools/flake8.py
+++ b/bot/reviewbot/tools/flake8.py
@@ -71,6 +71,7 @@ class Flake8Tool(Tool):
         output = execute(
             [
                 'flake8',
+                '--exit-zero',
                 '--max-line-length=%s' % settings['max_line_length'],
                 '--ignore=%s' % settings['ignore'],
                 path,


### PR DESCRIPTION
`flake8` returns non-zero status if it runs successfully and finds issues. This means the tool had to pass `ignore_errors=True` in order to ensure `flake8` finding issues wasn't reported as `internal error`.

This would mask actual internal errors however, and would result in the bot reporting that `flake8` "passed" in the event of an actual internal error.

Fixes [4710](https://hellosplat.com/s/beanbag/tickets/4710/)