### PR TITLE
Fix iterating over paginated resource.

### DIFF
--- a/bot/reviewbot/processing/review.py
+++ b/bot/reviewbot/processing/review.py
@@ -673,7 +673,7 @@ class Review(object):
                 review_request_id=self.review_request_id,
                 diff_revision=self.diff_revision)
 
-            for filediff in filediffs:
+            for filediff in filediffs.all_items:
                 # Filter out binary files and symlinks.
                 if (getattr(filediff, 'binary', False) or
                     filediff.status not in self._VALID_FILEDIFF_STATUS_TYPES or


### PR DESCRIPTION
The filediffs is the `ListResource` instance, which iterates only for the first `self.num_items` files. And that is only the first page.
While the `all_items` property explicitly goes through `self.all_pages` in a first place.