### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/bot/reviewbot/config.py
+++ b/bot/reviewbot/config.py
@@ -94,7 +94,7 @@ def get_config_file_path():
 
 
 def load_config():
-    """Load the Review Bot configuraiton.
+    """Load the Review Bot configuration.
 
     This will load the configuration file :file:`reviewbot/config.py`,
     located in the system's main configuration directory (:file:`/etc/` on

--- a/bot/reviewbot/main.py
+++ b/bot/reviewbot/main.py
@@ -135,7 +135,7 @@ def create_arg_parser():
         help=(
             'Enable auto-scaling of workers. The value is in the form of '
             'max_concurrency,min_concurrency. For example, --autoscale=10,3 '
-            'will keep 3 proceses, but grow to 10 if needed.'
+            'will keep 3 processes, but grow to 10 if needed.'
         ))
 
     return arg_parser

--- a/bot/reviewbot/processing/review.py
+++ b/bot/reviewbot/processing/review.py
@@ -59,7 +59,7 @@ class ReviewFileStatus(Enum):
 class File(object):
     """Represents a file in the review.
 
-    Information about the file can be retreived through this class,
+    Information about the file can be retrieved through this class,
     including retrieving the actual body of the original or patched
     file.
 

--- a/bot/reviewbot/testing/testcases.py
+++ b/bot/reviewbot/testing/testcases.py
@@ -655,7 +655,7 @@ class TestCase(unittest.TestCase):
 
         Args:
             chunks (list of dict):
-                A simplifed list of chunk data. Each should have the
+                A simplified list of chunk data. Each should have the
                 following keys:
 
                 ``change``:

--- a/bot/reviewbot/tests/test_celery.py
+++ b/bot/reviewbot/tests/test_celery.py
@@ -44,7 +44,7 @@ class SetupCookiesTests(kgb.SpyAgency, TestCase):
         shutil.rmtree(self.cookie_root)
 
     def test_with_nonexistant_cookie_dir(self):
-        """Testing setup_cookies with non-existant cookie directory"""
+        """Testing setup_cookies with non-existent cookie directory"""
         os.rmdir(self.cookie_dir)
 
         with self.override_config(self.config):
@@ -62,7 +62,7 @@ class SetupCookiesTests(kgb.SpyAgency, TestCase):
             self.cookie_path)
 
     def test_with_nonexistant_cookie_dir_cant_create(self):
-        """Testing setup_cookies with non-existant cookie directory that
+        """Testing setup_cookies with non-existent cookie directory that
         can't be created
         """
         cookie_path = '/dev/null/cookies/reviewbot-cookies.txt'
@@ -120,7 +120,7 @@ class SetupCookiesTests(kgb.SpyAgency, TestCase):
             cookie_path)
 
     def test_with_nonexistant_cookie_path_cant_write(self):
-        """Testing setup_cookies with non-existant cookie file that can't be
+        """Testing setup_cookies with non-existent cookie file that can't be
         written to
         """
         cookie_path = self.cookie_path

--- a/bot/reviewbot/utils/filesystem.py
+++ b/bot/reviewbot/utils/filesystem.py
@@ -253,7 +253,7 @@ def normalize_platform_path(path, relative_to=None,
          norm_path.startswith('//'))):
         # This is an absolute path, or a UNC path. posixpath.splitdrive()
         # won't handle UNC paths, but ntpath.splitdrive() will (and handle
-        # either / or \ delimeters.
+        # either / or \ delimiters.
         norm_path = ntpath.splitdrive(norm_path)[1]
 
     # Convert the path delimiter.

--- a/docs/releasenotes/3.0.rst
+++ b/docs/releasenotes/3.0.rst
@@ -181,7 +181,7 @@ New Tools
 
 * :ref:`tool-shellcheck`
 
-  This tool checks stanard shell scripts for common problems and misused
+  This tool checks standard shell scripts for common problems and misused
   commands.
 
   This supports :file:`*.bash`, :file:`*.bats`, :file:`*.dash`,

--- a/extension/reviewbotext/integration.py
+++ b/extension/reviewbotext/integration.py
@@ -265,7 +265,7 @@ class ReviewBotIntegration(Integration):
             review_request, service_id=service_id))
 
         if not matching_configs:
-            # While the service ID indentified status_update as coming from
+            # While the service ID identified status_update as coming from
             # Review Bot, it doesn't match any active configs, so there's
             # nothing we can do.
             return


### PR DESCRIPTION
% `codespell --ignore-words-list=assertin,filetests,referes --write-changes`
* https://pypi.org/project/codespell